### PR TITLE
Resolve go-imports meta tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ RUN apk update && \
   rm -rf \
     /var/cache/apk/*
 
-CMD ["/usr/sbin/caddy", "-port", "80", "-root", "/srv/www"]
-ADD public /srv/www
+CMD ["/usr/sbin/caddy", "-conf", "/etc/caddy/caddy.conf"]
+
+COPY docker/caddy.conf /etc/caddy/caddy.conf
+COPY public /srv/www

--- a/docker/caddy.conf
+++ b/docker/caddy.conf
@@ -1,0 +1,18 @@
+:80 {
+  root /srv/www
+
+  rewrite {
+    regexp /gitea/.+
+    to /gitea
+  }
+
+  rewrite {
+    regexp /sdk/.+
+    to /sdk
+  }
+
+  rewrite {
+    regexp /git/.+
+    to /git
+  }
+}


### PR DESCRIPTION
Maybe this is not the most elegant solution but it should work. We
always need to display the same meta tags, Now I'm rewriting the
requested route always to the main folder. This should be more dynamic
in the future.